### PR TITLE
Add alabama dependency package to DESCRIPTION file so that the package builds

### DIFF
--- a/MRMiSTERI/DESCRIPTION
+++ b/MRMiSTERI/DESCRIPTION
@@ -9,4 +9,4 @@ License: MIT
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1
-
+Imports: alabama


### PR DESCRIPTION
Hi there

Currently this package doesn't build because you have accidentally forgotten to declare the **alabama** dependency package in your DESCRIPTION file. This PR adds that.

With best wishes
  Tom
